### PR TITLE
feat(hazard_status_converter): hazard status converter subscribe emergency holding

### DIFF
--- a/system/hazard_status_converter/launch/hazard_status_converter.launch.xml
+++ b/system/hazard_status_converter/launch/hazard_status_converter.launch.xml
@@ -2,5 +2,6 @@
   <node pkg="hazard_status_converter" exec="converter" name="hazard_status_converter">
     <remap from="~/diagnostics_graph" to="/diagnostics_graph"/>
     <remap from="~/hazard_status" to="/system/emergency/hazard_status"/>
+    <remap from="~/input/emergency_holding" to="/system/emergency_holding"/>
   </node>
 </launch>

--- a/system/hazard_status_converter/package.xml
+++ b/system/hazard_status_converter/package.xml
@@ -12,6 +12,7 @@
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_system_msgs</depend>
+  <depend>autoware_universe_utils</depend>
   <depend>diagnostic_graph_utils</depend>
   <depend>diagnostic_msgs</depend>
   <depend>rclcpp</depend>

--- a/system/hazard_status_converter/src/converter.cpp
+++ b/system/hazard_status_converter/src/converter.cpp
@@ -119,7 +119,7 @@ void Converter::on_update(DiagGraph::ConstSharedPtr graph)
   hazard.status.emergency = hazard.status.level == HazardStatus::SINGLE_POINT_FAULT;
 
   auto is_emergency_holding = sub_emergency_holding_.takeData();
-  hazard.status.emergency_holding = is_emergency_holding == nullptr ? false : is_emergency_holding->holding;
+  hazard.status.emergency_holding = is_emergency_holding == nullptr ? false : is_emergency_holding->is_holding;
   pub_hazard_->publish(hazard);
 }
 

--- a/system/hazard_status_converter/src/converter.cpp
+++ b/system/hazard_status_converter/src/converter.cpp
@@ -117,7 +117,9 @@ void Converter::on_update(DiagGraph::ConstSharedPtr graph)
   hazard.stamp = graph->updated_stamp();
   hazard.status.level = get_system_level(hazard.status);
   hazard.status.emergency = hazard.status.level == HazardStatus::SINGLE_POINT_FAULT;
-  hazard.status.emergency_holding = false;
+
+  auto is_emergency_holding = sub_emergency_holding_.takeData();
+  hazard.status.emergency_holding = is_emergency_holding == nullptr ? false : is_emergency_holding->holding;
   pub_hazard_->publish(hazard);
 }
 

--- a/system/hazard_status_converter/src/converter.hpp
+++ b/system/hazard_status_converter/src/converter.hpp
@@ -16,9 +16,11 @@
 #define CONVERTER_HPP_
 
 #include <diagnostic_graph_utils/subscription.hpp>
+#include <autoware/universe_utils/ros/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_system_msgs/msg/hazard_status_stamped.hpp>
+#include <tier4_system_msgs/msg/emergency_holding_state.hpp>
 
 #include <unordered_set>
 
@@ -38,6 +40,8 @@ private:
   void on_update(DiagGraph::ConstSharedPtr graph);
   diagnostic_graph_utils::DiagGraphSubscription sub_graph_;
   rclcpp::Publisher<HazardStatusStamped>::SharedPtr pub_hazard_;
+  autoware::universe_utils::InterProcessPollingSubscriber<tier4_system_msgs::msg::EmergencyHoldingState>
+    sub_emergency_holding_{this, "~/input/emergency_holding"};
 
   DiagUnit * auto_mode_root_;
   std::unordered_set<DiagUnit *> auto_mode_tree_;


### PR DESCRIPTION
## Description
This PR add emergency holding subscriber and update `emergency_holding` which is in `hazard_status` topic .

## Related links
**Parent Issue:**

- [CompanyName internal link](https://star4.slack.com/archives/C017VB9UG1L/p1729675438504999)
- [tier4_autoware_msgs PR link]()

## How was this PR tested?
Please refer to the [parent PR](https://github.com/autowarefoundation/autoware.universe/pull/9285).

## Notes for reviewers

None.

## Interface changes

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added | Sub| `/system/emergency_holding` | `tier4_system_msgs/msg/EmergencyHoldingState`   | indicates whether mrm is in the emergency_holding state|

## Effects on system behavior

None.
